### PR TITLE
Add Hugz Visuals marketing site

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,0 +1,144 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>À propos — Hugz Visuals</title>
+  <meta name="description" content="Découvrez l’univers de Hugz Visuals : vidéaste et photographe dans le sud de la France, spécialisé dans les histoires lumineuses et authentiques." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Montserrat:wght@600;700;800&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="css/style.css" />
+</head>
+<body>
+  <header>
+    <nav class="navbar">
+      <a href="index.html" class="logo">Hugz Visuals</a>
+      <button class="mobile-toggle" aria-label="Ouvrir le menu" aria-expanded="false">
+        <span class="material-symbols-outlined">≡</span>
+      </button>
+      <div class="nav-links">
+        <a href="index.html">Accueil</a>
+        <a href="about.html">À propos</a>
+        <a href="services.html">Services</a>
+        <a href="blog.html">Blog</a>
+        <a href="contact.html" class="btn">Contact</a>
+      </div>
+    </nav>
+  </header>
+  <main>
+    <section class="section">
+      <div class="main-wrapper">
+        <nav aria-label="Fil d’Ariane" class="breadcrumbs">
+          <a href="index.html">Accueil</a>
+          <span>/</span>
+          <span>À propos</span>
+        </nav>
+        <div class="about-wrapper">
+          <div class="text fade-in">
+            <span class="badge">Rencontrez Hugz</span>
+            <h2>Une vision guidée par la lumière du Sud</h2>
+            <p>Je suis Hugo, alias Hugz Visuals. Originaire de Marseille, j’ai grandi entre la mer et la montagne, fasciné par la manière dont la lumière embrase les paysages. Après des études en audiovisuel et plusieurs années dans des agences créatives, j’ai décidé de me lancer pour raconter des histoires vraies avec ma caméra.</p>
+            <p>Ma signature : un mélange entre douceur méditerranéenne, cadrages cinématiques et storytelling instinctif. J’aime construire des expériences sensorielles, travailler avec les textures naturelles, jouer avec les ombres et donner vie aux projets qui me sont confiés.</p>
+            <div class="highlight">
+              <p>Basé à Marseille, je me déplace dans tout le sud de la France : Provence, Côte d’Azur, Occitanie et au-delà pour les projets qui vibrent.</p>
+            </div>
+            <div class="btn-group">
+              <a href="services.html" class="btn">Explorer mes offres</a>
+              <a href="contact.html" class="btn secondary">Planifier un appel découverte</a>
+            </div>
+          </div>
+          <div class="gallery">
+            <img data-src="https://images.unsplash.com/photo-1529359744902-5518d0f3a162?auto=format&fit=crop&w=800&q=80" alt="Hugz Visuals en tournage" class="lazy" loading="lazy" />
+            <img data-src="https://images.unsplash.com/photo-1524253482453-3fed8d2fe12b?auto=format&fit=crop&w=800&q=80" alt="Matériel vidéo professionnel" class="lazy" loading="lazy" />
+            <img data-src="https://images.unsplash.com/photo-1498050108023-c5249f4df085?auto=format&fit=crop&w=800&q=80" alt="Ambiance de montage" class="lazy" loading="lazy" />
+            <img data-src="https://images.unsplash.com/photo-1526170375885-4d8ecf77b99f?auto=format&fit=crop&w=800&q=80" alt="Paysage méditerranéen" class="lazy" loading="lazy" />
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section alt">
+      <div class="main-wrapper">
+        <h2>Approche & valeurs</h2>
+        <div class="tablet-stacked">
+          <div class="card fade-in">
+            <h3>Sincérité</h3>
+            <p>Je privilégie les échanges humains et la compréhension profonde de vos besoins pour créer des images qui vibrent avec votre personnalité.</p>
+          </div>
+          <div class="card fade-in">
+            <h3>Esthétique</h3>
+            <p>Je soigne chaque plan, chaque transition et chaque teinte pour une esthétique moderne et intemporelle.</p>
+          </div>
+          <div class="card fade-in">
+            <h3>Exigence</h3>
+            <p>Du repérage à la livraison, je supervise chaque étape avec rigueur afin de garantir un rendu professionnel et cohérent.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section light">
+      <div class="main-wrapper split-section large-gap">
+        <div class="fade-in">
+          <h2>Mon parcours</h2>
+          <p>Depuis plus de 8 ans, je collabore avec des couples, des marques et des artistes. J’ai travaillé pour des festivals de musique, des créateurs locaux et des entreprises en quête de contenus authentiques. Mon studio est un laboratoire d’idées où je mêle direction artistique, tournage et post-production.</p>
+          <blockquote>« Mon objectif est de faire ressentir la chaleur d’un instant, la puissance d’une histoire et la personnalité de ceux qui la vivent. »</blockquote>
+        </div>
+        <div class="card reveal">
+          <h3>Quelques repères</h3>
+          <ul>
+            <li>+120 projets filmés entre 2016 et 2024</li>
+            <li>Membre du collectif créatif Sud Visual</li>
+            <li>Disponible en français, anglais et espagnol</li>
+            <li>Équipement cinéma : Sony FX3, drones DJI, optiques Zeiss</li>
+          </ul>
+          <div class="cta-wrap">
+            <a href="contact.html" class="btn">Démarrer une collaboration</a>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="cta-banner fade-in">
+        <h3>Envie de créer ensemble ?</h3>
+        <p>Racontez-moi votre histoire, votre projet ou votre idée. Je reviens vers vous avec un plan d’action sur-mesure.</p>
+        <div class="btn-group">
+          <a href="contact.html" class="btn">Je prends rendez-vous</a>
+          <a href="mailto:hello@hugzvisuals.com" class="btn secondary">hello@hugzvisuals.com</a>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <div class="inner">
+      <div class="footer-top">
+        <div>
+          <h4>Hugz Visuals</h4>
+          <p>Vidéaste & photographe basé à Marseille. Disponible dans toute la région Sud & au-delà.</p>
+        </div>
+        <div>
+          <h4>Contact</h4>
+          <p><a href="mailto:hello@hugzvisuals.com">hello@hugzvisuals.com</a></p>
+          <p><a href="tel:+33600000000">+33 6 00 00 00 00</a></p>
+        </div>
+        <div>
+          <h4>Suivre</h4>
+          <div class="social-links">
+            <a href="#" aria-label="Instagram">IG</a>
+            <a href="#" aria-label="Vimeo">VI</a>
+            <a href="#" aria-label="YouTube">YT</a>
+          </div>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <span>© <span id="year">2024</span> Hugz Visuals. Tous droits réservés.</span>
+        <a href="mailto:hello@hugzvisuals.com">Parler du prochain projet</a>
+      </div>
+    </div>
+  </footer>
+  <script src="js/main.js" defer></script>
+</body>
+</html>

--- a/blog-post.html
+++ b/blog-post.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Comment préparer un tournage nocturne inoubliable — Blog Hugz Visuals</title>
+  <meta name="description" content="Conseils pratiques pour réussir un tournage de nuit : repérage, matériel, éclairages et direction artistique par Hugz Visuals." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Montserrat:wght@600;700;800&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="css/style.css" />
+</head>
+<body>
+  <header>
+    <nav class="navbar">
+      <a href="index.html" class="logo">Hugz Visuals</a>
+      <button class="mobile-toggle" aria-label="Ouvrir le menu" aria-expanded="false">
+        <span class="material-symbols-outlined">≡</span>
+      </button>
+      <div class="nav-links">
+        <a href="index.html">Accueil</a>
+        <a href="about.html">À propos</a>
+        <a href="services.html">Services</a>
+        <a href="blog.html">Blog</a>
+        <a href="contact.html" class="btn">Contact</a>
+      </div>
+    </nav>
+  </header>
+  <main>
+    <section class="section">
+      <div class="main-wrapper">
+        <nav aria-label="Fil d’Ariane" class="breadcrumbs">
+          <a href="index.html">Accueil</a>
+          <span>/</span>
+          <a href="blog.html">Blog</a>
+          <span>/</span>
+          <span>Comment préparer un tournage nocturne</span>
+        </nav>
+        <article class="article-wrapper">
+          <header>
+            <span class="meta">Production • 5 min de lecture</span>
+            <h1>Comment préparer un tournage nocturne inoubliable</h1>
+          </header>
+          <p>Les tournages de nuit possèdent une atmosphère unique : les néons vibrent, les ombres s’allongent et la ville se transforme. Pourtant, capturer cette magie demande une préparation millimétrée. Voici mon approche pour créer des images de nuit à la fois percutantes et poétiques.</p>
+          <h2>1. Repérage et storyboard lumineux</h2>
+          <p>Je commence toujours par repérer les lieux de jour et de nuit. L’objectif est de comprendre comment la lumière artificielle se pose, quels néons fonctionnent, où placer les sujets pour obtenir un contraste fort. Un storyboard est ensuite réalisé pour planifier les plans clés et anticiper les sources lumineuses.</p>
+          <h2>2. Choisir le bon matériel</h2>
+          <p>Les caméras plein format à grande latitude, des optiques lumineuses (f/1.4 à f/2) et des stabilisateurs me permettent de capturer des mouvements fluides sans bruit numérique excessif. Je prévois aussi des panneaux LED légers et des tubes RGB afin de modeler la lumière sur le visage des sujets.</p>
+          <blockquote>« La nuit n’est pas une contrainte, c’est un terrain de jeu pour créer un univers visuel unique. »</blockquote>
+          <h2>3. Diriger le rythme du tournage</h2>
+          <p>Un tournage nocturne doit rester dynamique : j’alterne plans larges et détails, je propose des actions courtes aux talents pour garder une énergie naturelle. Je planifie des pauses pour maintenir la concentration et vérifier régulièrement l’exposition.</p>
+          <h2>4. Travailler la post-production</h2>
+          <p>L’étalonnage est crucial. Je crée des looks chromatiques inspirés du cinéma, je travaille les hautes lumières pour éviter les surexpositions et je renforce les teintes bleues et orangées pour une ambiance contrastée. Le sound design vient sublimer l’ensemble.</p>
+          <p>Envie de réaliser un tournage nocturne pour votre marque, votre clip ou votre court-métrage ? Parlons-en !</p>
+          <div class="cta-wrap">
+            <a href="contact.html" class="btn">Discuter de votre projet</a>
+          </div>
+        </article>
+      </div>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <div class="inner">
+      <div class="footer-top">
+        <div>
+          <h4>Hugz Visuals</h4>
+          <p>Vidéaste & photographe basé à Marseille. Disponible dans toute la région Sud & au-delà.</p>
+        </div>
+        <div>
+          <h4>Contact</h4>
+          <p><a href="mailto:hello@hugzvisuals.com">hello@hugzvisuals.com</a></p>
+          <p><a href="tel:+33600000000">+33 6 00 00 00 00</a></p>
+        </div>
+        <div>
+          <h4>Suivre</h4>
+          <div class="social-links">
+            <a href="#" aria-label="Instagram">IG</a>
+            <a href="#" aria-label="Vimeo">VI</a>
+            <a href="#" aria-label="YouTube">YT</a>
+          </div>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <span>© <span id="year">2024</span> Hugz Visuals. Tous droits réservés.</span>
+        <a href="mailto:hello@hugzvisuals.com">Parler du prochain projet</a>
+      </div>
+    </div>
+  </footer>
+  <script src="js/main.js" defer></script>
+</body>
+</html>

--- a/blog.html
+++ b/blog.html
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Blog — Hugz Visuals</title>
+  <meta name="description" content="Conseils, coulisses et inspirations par Hugz Visuals. Découvrez des articles sur la vidéo, la photographie, la production et le storytelling visuel." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Montserrat:wght@600;700;800&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="css/style.css" />
+</head>
+<body>
+  <header>
+    <nav class="navbar">
+      <a href="index.html" class="logo">Hugz Visuals</a>
+      <button class="mobile-toggle" aria-label="Ouvrir le menu" aria-expanded="false">
+        <span class="material-symbols-outlined">≡</span>
+      </button>
+      <div class="nav-links">
+        <a href="index.html">Accueil</a>
+        <a href="about.html">À propos</a>
+        <a href="services.html">Services</a>
+        <a href="blog.html">Blog</a>
+        <a href="contact.html" class="btn">Contact</a>
+      </div>
+    </nav>
+  </header>
+  <main>
+    <section class="blog-hero">
+      <div class="hero-content">
+        <span class="badge">Le journal des images</span>
+        <h1>Inspirations, coulisses & conseils de production</h1>
+        <p>Plongez dans mes carnets de tournage, découvrez mes astuces pour préparer votre séance et apprenez à raconter une histoire visuelle puissante.</p>
+        <div class="btn-group">
+          <a href="contact.html" class="btn">Discuter d’un projet</a>
+          <a href="#articles" class="btn secondary">Explorer les articles</a>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" id="articles">
+      <div class="main-wrapper">
+        <nav aria-label="Fil d’Ariane" class="breadcrumbs">
+          <a href="index.html">Accueil</a>
+          <span>/</span>
+          <span>Blog</span>
+        </nav>
+        <div class="split-section large-gap">
+          <div>
+            <h2>Derniers articles</h2>
+            <p class="section-intro">Une sélection d’articles pour vous guider à travers la préparation, le tournage et la diffusion de vos contenus visuels.</p>
+            <div class="blog-list">
+              <article class="blog-card fade-in">
+                <img src="https://images.unsplash.com/photo-1469474968028-56623f02e42e?auto=format&fit=crop&w=1200&q=70" alt="Plan de tournage de nuit" loading="lazy" />
+                <div class="content">
+                  <span class="meta">Production • 5 min</span>
+                  <h3><a href="blog-post.html">Comment préparer un tournage nocturne inoubliable</a></h3>
+                  <p>Repérage, éclairages, rythme de tournage : je partage ma méthode pour capturer l’âme de la nuit sans sacrifier la qualité.</p>
+                  <a href="blog-post.html" class="more">Lire l’article</a>
+                </div>
+              </article>
+
+              <article class="blog-card fade-in">
+                <img src="https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=1200&q=70" alt="Portrait lifestyle lumineux" loading="lazy" />
+                <div class="content">
+                  <span class="meta">Photographie • 4 min</span>
+                  <h3><a href="blog-post.html">5 astuces pour une séance lifestyle naturelle</a></h3>
+                  <p>De la préparation du lieu aux micro-mouvements, découvrez comment je crée des séances photo fluides et authentiques.</p>
+                  <a href="blog-post.html" class="more">Lire l’article</a>
+                </div>
+              </article>
+
+              <article class="blog-card fade-in">
+                <img src="https://images.unsplash.com/photo-1526170375885-4d8ecf77b99f?auto=format&fit=crop&w=1200&q=70" alt="Paysage méditerranéen" loading="lazy" />
+                <div class="content">
+                  <span class="meta">Inspiration • 6 min</span>
+                  <h3><a href="blog-post.html">Mes spots préférés au lever du soleil en Provence</a></h3>
+                  <p>Un tour d’horizon des lieux qui m’inspirent pour capter la lumière dorée et la douceur méditerranéenne.</p>
+                  <a href="blog-post.html" class="more">Lire l’article</a>
+                </div>
+              </article>
+            </div>
+          </div>
+          <aside class="card reveal">
+            <h3>Thématiques populaires</h3>
+            <ul>
+              <li><a href="#">Préparer son mariage</a></li>
+              <li><a href="#">Conseils entrepreneurs</a></li>
+              <li><a href="#">Équipement & gear</a></li>
+              <li><a href="#">Post-production</a></li>
+            </ul>
+            <div class="cta-wrap">
+              <a href="contact.html" class="btn">Proposer un sujet</a>
+            </div>
+          </aside>
+        </div>
+      </div>
+    </section>
+
+    <section class="section alt">
+      <div class="main-wrapper">
+        <h2>S’inscrire à la lettre créative</h2>
+        <div class="cta-banner fade-in">
+          <p>Recevez chaque mois des idées de tournage, des presets exclusifs et les coulisses de mes productions.</p>
+          <form class="tablet-stacked" data-form="newsletter">
+            <label for="newsletter-email" class="sr-only">Adresse e-mail</label>
+            <input type="email" id="newsletter-email" name="email" placeholder="Votre e-mail" required />
+            <button type="submit" class="btn">Je m’inscris</button>
+          </form>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <div class="inner">
+      <div class="footer-top">
+        <div>
+          <h4>Hugz Visuals</h4>
+          <p>Vidéaste & photographe basé à Marseille. Disponible dans toute la région Sud & au-delà.</p>
+        </div>
+        <div>
+          <h4>Contact</h4>
+          <p><a href="mailto:hello@hugzvisuals.com">hello@hugzvisuals.com</a></p>
+          <p><a href="tel:+33600000000">+33 6 00 00 00 00</a></p>
+        </div>
+        <div>
+          <h4>Suivre</h4>
+          <div class="social-links">
+            <a href="#" aria-label="Instagram">IG</a>
+            <a href="#" aria-label="Vimeo">VI</a>
+            <a href="#" aria-label="YouTube">YT</a>
+          </div>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <span>© <span id="year">2024</span> Hugz Visuals. Tous droits réservés.</span>
+        <a href="mailto:hello@hugzvisuals.com">Parler du prochain projet</a>
+      </div>
+    </div>
+  </footer>
+  <script src="js/main.js" defer></script>
+</body>
+</html>

--- a/contact.html
+++ b/contact.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Contact — Hugz Visuals</title>
+  <meta name="description" content="Contactez Hugz Visuals pour vos projets photo et vidéo : mariages, brand content, clips, campagnes, événements. Réponse rapide en 24h." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Montserrat:wght@600;700;800&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="css/style.css" />
+</head>
+<body>
+  <header>
+    <nav class="navbar">
+      <a href="index.html" class="logo">Hugz Visuals</a>
+      <button class="mobile-toggle" aria-label="Ouvrir le menu" aria-expanded="false">
+        <span class="material-symbols-outlined">≡</span>
+      </button>
+      <div class="nav-links">
+        <a href="index.html">Accueil</a>
+        <a href="about.html">À propos</a>
+        <a href="services.html">Services</a>
+        <a href="blog.html">Blog</a>
+        <a href="contact.html" class="btn">Contact</a>
+      </div>
+    </nav>
+  </header>
+  <main>
+    <section class="section">
+      <div class="main-wrapper">
+        <nav aria-label="Fil d’Ariane" class="breadcrumbs">
+          <a href="index.html">Accueil</a>
+          <span>/</span>
+          <span>Contact</span>
+        </nav>
+        <div class="split-section large-gap">
+          <div class="contact-info fade-in">
+            <span class="badge">Parlons de votre projet</span>
+            <h2>Créez des images mémorables</h2>
+            <p>Écrivez-moi quelques mots sur votre projet : la date, le lieu, le type de prestation et vos envies. Je reviens vers vous sous 24h avec une proposition détaillée.</p>
+            <ul>
+              <li>Email : <a href="mailto:hello@hugzvisuals.com">hello@hugzvisuals.com</a></li>
+              <li>Téléphone : <a href="tel:+33600000000">+33 6 00 00 00 00</a></li>
+              <li>Basé à Marseille — déplacements dans tout le sud de la France et au-delà</li>
+              <li>Disponible du lundi au samedi, 9h-19h</li>
+            </ul>
+            <div class="social-links">
+              <a href="#" aria-label="Instagram">IG</a>
+              <a href="#" aria-label="Vimeo">VI</a>
+              <a href="#" aria-label="YouTube">YT</a>
+            </div>
+          </div>
+          <div class="card reveal">
+            <h3>Formulaire de contact</h3>
+            <form data-form="contact">
+              <label for="name">Nom complet</label>
+              <input type="text" id="name" name="name" placeholder="Votre nom" required />
+
+              <label for="email">Adresse e-mail</label>
+              <input type="email" id="email" name="email" placeholder="Votre email" required />
+
+              <label for="message">Votre message</label>
+              <textarea id="message" name="message" placeholder="Parlez-moi de votre projet" required></textarea>
+
+              <button type="submit" class="btn">Envoyer le message</button>
+            </form>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section light">
+      <div class="main-wrapper split-section large-gap">
+        <div class="map fade-in">
+          <iframe title="Localisation Hugz Visuals" src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d11529.214195563579!2d5.36978!3d43.296482!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x12c9c0ae4731f8b7%3A0x41b82c368a0c1!2sMarseille!5e0!3m2!1sfr!2sfr!4v1681245678901!5m2!1sfr!2sfr" width="100%" height="100%" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+        </div>
+        <div class="card reveal">
+          <h3>Questions fréquentes</h3>
+          <ul>
+            <li>Délai moyen de livraison : 2 à 4 semaines selon le projet.</li>
+            <li>Accompagnement complet de la pré-production à la livraison.</li>
+            <li>Possibilité de paiement en plusieurs fois.</li>
+            <li>Déplacements facturés hors région Sud.</li>
+          </ul>
+          <div class="cta-wrap">
+            <a href="mailto:hello@hugzvisuals.com" class="btn secondary">Envoyer une note vocale</a>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <div class="inner">
+      <div class="footer-top">
+        <div>
+          <h4>Hugz Visuals</h4>
+          <p>Vidéaste & photographe basé à Marseille. Disponible dans toute la région Sud & au-delà.</p>
+        </div>
+        <div>
+          <h4>Contact</h4>
+          <p><a href="mailto:hello@hugzvisuals.com">hello@hugzvisuals.com</a></p>
+          <p><a href="tel:+33600000000">+33 6 00 00 00 00</a></p>
+        </div>
+        <div>
+          <h4>Suivre</h4>
+          <div class="social-links">
+            <a href="#" aria-label="Instagram">IG</a>
+            <a href="#" aria-label="Vimeo">VI</a>
+            <a href="#" aria-label="YouTube">YT</a>
+          </div>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <span>© <span id="year">2024</span> Hugz Visuals. Tous droits réservés.</span>
+        <a href="mailto:hello@hugzvisuals.com">Parler du prochain projet</a>
+      </div>
+    </div>
+  </footer>
+  <script src="js/main.js" defer></script>
+</body>
+</html>

--- a/css/style.css
+++ b/css/style.css
@@ -1,0 +1,876 @@
+:root {
+  --bg-dark: #0c0c0f;
+  --bg-light: #f8f8f8;
+  --accent: #f2b705;
+  --accent-secondary: #2a9d8f;
+  --text-primary: #fdfdfd;
+  --text-secondary: rgba(255, 255, 255, 0.78);
+  --text-dark: #1a1a1a;
+  --font-display: 'Montserrat', 'Helvetica Neue', Arial, sans-serif;
+  --font-body: 'Inter', 'Helvetica Neue', Arial, sans-serif;
+  --max-width: 1200px;
+  --transition-base: all 0.4s ease;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: var(--font-body);
+  background-color: var(--bg-dark);
+  color: var(--text-primary);
+  line-height: 1.6;
+  scroll-behavior: smooth;
+}
+
+img, video {
+  max-width: 100%;
+  height: auto;
+  display: block;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+ul {
+  list-style: none;
+}
+
+header {
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  background: rgba(12, 12, 15, 0.85);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.navbar {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.25rem 2rem;
+}
+
+.logo {
+  font-family: var(--font-display);
+  font-size: 1.45rem;
+  letter-spacing: 0.3rem;
+  text-transform: uppercase;
+  font-weight: 700;
+}
+
+.nav-links {
+  display: flex;
+  gap: 1.5rem;
+  align-items: center;
+}
+
+.nav-links a {
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08rem;
+  color: var(--text-secondary);
+  position: relative;
+  padding-bottom: 0.2rem;
+  transition: var(--transition-base);
+}
+
+.nav-links a::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 0;
+  height: 2px;
+  background: var(--accent);
+  transition: var(--transition-base);
+}
+
+.nav-links a:hover,
+.nav-links a.active {
+  color: var(--text-primary);
+}
+
+.nav-links a:hover::after,
+.nav-links a.active::after {
+  width: 100%;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.9rem 1.8rem;
+  border-radius: 999px;
+  text-transform: uppercase;
+  letter-spacing: 0.08rem;
+  font-weight: 600;
+  font-size: 0.9rem;
+  background: var(--accent);
+  color: #0b0b0d;
+  border: none;
+  cursor: pointer;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.btn.secondary {
+  background: transparent;
+  color: var(--text-primary);
+  border: 1px solid rgba(255, 255, 255, 0.4);
+}
+
+.btn:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 12px 30px rgba(242, 183, 5, 0.3);
+}
+
+.btn.secondary:hover {
+  box-shadow: 0 10px 20px rgba(255, 255, 255, 0.15);
+}
+
+.hero {
+  position: relative;
+  min-height: 90vh;
+  display: grid;
+  place-items: center;
+  text-align: center;
+  overflow: hidden;
+}
+
+.hero video,
+.hero::before {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.hero::before {
+  content: "";
+  background: rgba(10, 10, 12, 0.55);
+  z-index: 1;
+}
+
+.hero-content {
+  position: relative;
+  z-index: 2;
+  padding: 0 1.5rem;
+  max-width: 720px;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.hero h1 {
+  font-family: var(--font-display);
+  font-size: clamp(2.5rem, 6vw, 4.5rem);
+  text-transform: uppercase;
+  letter-spacing: 0.4rem;
+}
+
+.hero p {
+  color: var(--text-secondary);
+  font-size: clamp(1.05rem, 2vw, 1.25rem);
+}
+
+.section {
+  padding: 5rem 1.5rem;
+  background: linear-gradient(180deg, rgba(12, 12, 15, 0.98), rgba(12, 12, 15, 0.95));
+}
+
+.section.alt {
+  background: #111116;
+}
+
+.section.light {
+  background: var(--bg-light);
+  color: var(--text-dark);
+}
+
+.section h2 {
+  font-family: var(--font-display);
+  font-size: clamp(2rem, 4vw, 3rem);
+  text-transform: uppercase;
+  letter-spacing: 0.25rem;
+  margin-bottom: 2rem;
+  text-align: center;
+}
+
+.section p.section-intro {
+  max-width: 680px;
+  margin: 0 auto 3rem;
+  text-align: center;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.section.light p.section-intro {
+  color: rgba(17, 17, 17, 0.72);
+}
+
+.grid {
+  display: grid;
+  gap: 2rem;
+}
+
+.grid-2 {
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.grid-3 {
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.card {
+  background: rgba(18, 18, 24, 0.85);
+  border-radius: 20px;
+  padding: 2.4rem;
+  position: relative;
+  overflow: hidden;
+  transition: transform 0.4s ease, background 0.4s ease;
+  backdrop-filter: blur(10px);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.section.light .card {
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(0, 0, 0, 0.05);
+}
+
+.card:hover {
+  transform: translateY(-10px);
+  background: rgba(26, 26, 32, 0.95);
+}
+
+.section.light .card:hover {
+  background: #ffffff;
+}
+
+.card h3 {
+  font-family: var(--font-display);
+  letter-spacing: 0.18rem;
+  margin-bottom: 1rem;
+  font-size: 1.3rem;
+}
+
+.card p {
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.section.light .card p {
+  color: rgba(26, 26, 26, 0.75);
+}
+
+.card .price {
+  display: block;
+  margin: 1.5rem 0 1rem;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.card .cta-wrap {
+  margin-top: 2rem;
+}
+
+.about-wrapper {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2.5rem;
+  align-items: center;
+}
+
+.about-wrapper .text {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.about-wrapper .text h3 {
+  font-size: 1rem;
+  letter-spacing: 0.3rem;
+  color: var(--accent);
+  text-transform: uppercase;
+}
+
+.about-wrapper .text p {
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.about-wrapper .gallery {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1rem;
+}
+
+.about-wrapper .gallery img {
+  width: 100%;
+  border-radius: 18px;
+  object-fit: cover;
+  height: 100%;
+  filter: saturate(1.05);
+}
+
+.highlight {
+  background: linear-gradient(135deg, rgba(242, 183, 5, 0.1), rgba(42, 157, 143, 0.08));
+  border-left: 3px solid var(--accent);
+  padding: 1.2rem 1.5rem;
+  border-radius: 14px;
+}
+
+.blog-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 2.5rem;
+}
+
+.blog-card {
+  border-radius: 20px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  transition: var(--transition-base);
+  display: flex;
+  flex-direction: column;
+}
+
+.blog-card img {
+  width: 100%;
+  height: 240px;
+  object-fit: cover;
+}
+
+.blog-card .content {
+  padding: 1.8rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  flex: 1;
+}
+
+.blog-card span.meta {
+  font-size: 0.85rem;
+  letter-spacing: 0.12rem;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+.blog-card a.more {
+  margin-top: auto;
+  color: var(--accent-secondary);
+  font-weight: 600;
+  letter-spacing: 0.08rem;
+  transition: color 0.3s ease;
+}
+
+.blog-card:hover {
+  transform: translateY(-12px);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.blog-card:hover a.more {
+  color: var(--accent);
+}
+
+.blog-hero {
+  background: url('assets/images/blog-hero.jpg') center/cover no-repeat;
+  min-height: 50vh;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}
+
+.blog-hero::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: rgba(10, 10, 12, 0.7);
+}
+
+.blog-hero .hero-content {
+  position: relative;
+  z-index: 2;
+}
+
+.blog-hero h1 {
+  font-size: clamp(2.5rem, 5vw, 4rem);
+}
+
+.article-wrapper {
+  max-width: 820px;
+  margin: 0 auto;
+  background: rgba(255, 255, 255, 0.05);
+  padding: 2.5rem;
+  border-radius: 22px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  backdrop-filter: blur(10px);
+}
+
+.article-wrapper h1 {
+  font-family: var(--font-display);
+  margin-bottom: 1rem;
+}
+
+.article-wrapper .meta {
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 0.9rem;
+  margin-bottom: 2rem;
+}
+
+.article-wrapper p {
+  margin-bottom: 1.4rem;
+  color: rgba(255, 255, 255, 0.78);
+}
+
+.services-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2.5rem;
+}
+
+.service-card {
+  position: relative;
+  padding: 3rem 2.2rem;
+  border-radius: 24px;
+  overflow: hidden;
+  background: radial-gradient(circle at top left, rgba(242, 183, 5, 0.12), rgba(12, 12, 15, 0.95));
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.service-card img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  opacity: 0.18;
+  z-index: 0;
+}
+
+.service-card .overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(12, 12, 15, 0.7), rgba(12, 12, 15, 0.95));
+  z-index: 1;
+}
+
+.service-card .content {
+  position: relative;
+  z-index: 2;
+}
+
+.service-card h3 {
+  font-size: 1.4rem;
+}
+
+.service-card ul {
+  display: grid;
+  gap: 0.6rem;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.service-card .cta-wrap {
+  margin-top: auto;
+}
+
+.testimonials {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 2rem;
+}
+
+.testimonial {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 20px;
+  padding: 2rem;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+}
+
+.testimonial p {
+  font-style: italic;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.testimonial span {
+  font-weight: 600;
+  letter-spacing: 0.12rem;
+  text-transform: uppercase;
+  color: var(--accent);
+  font-size: 0.85rem;
+}
+
+.cta-banner {
+  margin: 0 auto;
+  max-width: 960px;
+  padding: 3rem;
+  border-radius: 28px;
+  background: linear-gradient(135deg, rgba(242, 183, 5, 0.2), rgba(42, 157, 143, 0.2));
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.cta-banner h3 {
+  font-family: var(--font-display);
+  letter-spacing: 0.22rem;
+  text-transform: uppercase;
+}
+
+.contact-wrapper {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 2.5rem;
+}
+
+.contact-info {
+  background: rgba(255, 255, 255, 0.05);
+  padding: 2rem;
+  border-radius: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.contact-info h3 {
+  font-family: var(--font-display);
+  letter-spacing: 0.18rem;
+  text-transform: uppercase;
+}
+
+.contact-info ul {
+  display: grid;
+  gap: 0.75rem;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.contact-info a {
+  color: var(--accent);
+}
+
+form {
+  display: grid;
+  gap: 1.5rem;
+}
+
+label {
+  font-size: 0.85rem;
+  letter-spacing: 0.1rem;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+input,
+textarea {
+  width: 100%;
+  padding: 0.9rem 1rem;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text-primary);
+  font-size: 1rem;
+  transition: border 0.3s ease, box-shadow 0.3s ease;
+}
+
+input:focus,
+textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px rgba(242, 183, 5, 0.2);
+}
+
+textarea {
+  min-height: 180px;
+  resize: vertical;
+}
+
+.footer {
+  background: #0a0a0c;
+  padding: 3rem 1.5rem;
+}
+
+.footer .inner {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  display: grid;
+  gap: 2rem;
+}
+
+.footer-top {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 2rem;
+}
+
+.footer h4 {
+  font-family: var(--font-display);
+  letter-spacing: 0.16rem;
+  text-transform: uppercase;
+}
+
+.footer p,
+.footer a {
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.footer-bottom {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.4);
+}
+
+.social-links {
+  display: flex;
+  gap: 1rem;
+}
+
+.social-links a {
+  display: inline-flex;
+  width: 36px;
+  height: 36px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.08);
+  transition: var(--transition-base);
+}
+
+.social-links a:hover {
+  background: var(--accent);
+  color: #0b0b0d;
+}
+
+.mobile-toggle {
+  display: none;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  background: transparent;
+  color: var(--text-primary);
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+@media (max-width: 900px) {
+  .nav-links {
+    position: fixed;
+    inset: 0 0 0 40%;
+    background: rgba(10, 10, 12, 0.95);
+    flex-direction: column;
+    justify-content: center;
+    gap: 2rem;
+    transform: translateX(100%);
+    transition: transform 0.4s ease;
+  }
+
+  .nav-links.open {
+    transform: translateX(0);
+  }
+
+  .mobile-toggle {
+    display: inline-flex;
+  }
+}
+
+@media (max-width: 640px) {
+  .navbar {
+    padding: 1rem 1.2rem;
+  }
+
+  .hero {
+    min-height: 80vh;
+  }
+
+  .section {
+    padding: 4rem 1rem;
+  }
+
+  .card {
+    padding: 2rem 1.6rem;
+  }
+
+  .service-card {
+    padding: 2.5rem 1.6rem;
+  }
+
+  .cta-banner {
+    padding: 2.5rem 1.8rem;
+  }
+
+  .footer-bottom {
+    flex-direction: column;
+    text-align: center;
+  }
+}
+
+.fade-in {
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 0.6s ease, transform 0.6s ease;
+}
+
+.fade-in.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.reveal {
+  opacity: 0;
+  transform: translateY(40px);
+  transition: opacity 0.6s ease, transform 0.6s ease;
+}
+
+.reveal.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.hero .btn-group {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.18rem;
+  text-transform: uppercase;
+  padding: 0.45rem 0.85rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.split-section {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  display: grid;
+  gap: 2.5rem;
+}
+
+.split-section.large-gap {
+  gap: 4rem;
+}
+
+.process-steps {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.8rem;
+}
+
+.process-step {
+  background: rgba(255, 255, 255, 0.05);
+  padding: 2rem;
+  border-radius: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.process-step span {
+  font-size: 0.85rem;
+  letter-spacing: 0.24rem;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+.map {
+  border-radius: 20px;
+  overflow: hidden;
+  min-height: 280px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.breadcrumbs {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16rem;
+}
+
+.breadcrumbs a {
+  color: var(--accent-secondary);
+}
+
+.main-wrapper {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  display: grid;
+  gap: 3rem;
+}
+
+.section.light .breadcrumbs {
+  color: rgba(17, 17, 17, 0.6);
+}
+
+.section.light .breadcrumbs a {
+  color: var(--accent-secondary);
+}
+
+.tablet-stacked {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+blockquote {
+  border-left: 3px solid var(--accent);
+  padding-left: 1.5rem;
+  color: rgba(255, 255, 255, 0.7);
+  font-style: italic;
+}
+
+.section.light blockquote {
+  color: rgba(26, 26, 26, 0.7);
+}
+
+.gallery img.lazy {
+  filter: blur(12px);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+main {
+  overflow-x: hidden;
+}
+

--- a/index.html
+++ b/index.html
@@ -1,0 +1,187 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Hugz Visuals — Réalisateur & Photographe dans le Sud de la France</title>
+  <meta name="description" content="Hugz Visuals, vidéaste et photographe basé dans le sud de la France. Films de mariage, contenus de marques, clips musicaux et storytelling visuel captivant." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Montserrat:wght@600;700;800&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="css/style.css" />
+</head>
+<body>
+  <header>
+    <nav class="navbar">
+      <a href="index.html" class="logo">Hugz Visuals</a>
+      <button class="mobile-toggle" aria-label="Ouvrir le menu" aria-expanded="false">
+        <span class="material-symbols-outlined">≡</span>
+      </button>
+      <div class="nav-links">
+        <a href="index.html">Accueil</a>
+        <a href="about.html">À propos</a>
+        <a href="services.html">Services</a>
+        <a href="blog.html">Blog</a>
+        <a href="contact.html" class="btn">Contact</a>
+      </div>
+    </nav>
+  </header>
+  <main>
+    <section class="hero">
+      <video src="https://cdn.coverr.co/videos/coverr-couple-exploring-the-coast-2753/1080p.mp4" autoplay muted loop playsinline preload="metadata"></video>
+      <div class="hero-content">
+        <span class="badge">Sud de la France • Vidéo & Photo</span>
+        <h1>Raconter des histoires lumineuses</h1>
+        <p>Je capture l’émotion brute de vos instants précieux et l’énergie de vos projets pour créer des images qui vous ressemblent. Films immersifs, photographie éditoriale et storytelling authentique.</p>
+        <div class="btn-group">
+          <a href="contact.html" class="btn">Réserver une session</a>
+          <a href="services.html" class="btn secondary">Découvrir les services</a>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" id="highlights">
+      <div class="main-wrapper">
+        <div class="split-section fade-in">
+          <div>
+            <h2>Ce que je capture</h2>
+            <p class="section-intro">Mariages vibrants, clips musicaux, campagnes de marques, portraits personnels… Hugz Visuals conçoit des expériences visuelles immersives avec une signature cinématographique et une sensibilité éditoriale.</p>
+          </div>
+        </div>
+        <div class="grid grid-3">
+          <article class="card fade-in">
+            <h3>Films de mariage</h3>
+            <p>Des souvenirs sincères, des plans aériens poétiques, un montage dynamique qui raconte l’essence de votre journée.</p>
+            <span class="price">À partir de 1800€</span>
+            <div class="cta-wrap">
+              <a href="contact.html" class="btn">Planifier un appel</a>
+            </div>
+          </article>
+          <article class="card fade-in">
+            <h3>Stories de marque</h3>
+            <p>Des films courts et puissants pour révéler votre univers et créer le lien avec votre audience.</p>
+            <span class="price">À partir de 1200€</span>
+            <div class="cta-wrap">
+              <a href="services.html" class="btn secondary">Voir les packs</a>
+            </div>
+          </article>
+          <article class="card fade-in">
+            <h3>Portraits & Lifestyle</h3>
+            <p>Séances photo lumineuses et naturelles pour entrepreneurs, artistes et amoureux d’images fortes.</p>
+            <span class="price">À partir de 320€</span>
+            <div class="cta-wrap">
+              <a href="contact.html" class="btn">Demander un devis</a>
+            </div>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="section alt" id="featured-work">
+      <div class="main-wrapper">
+        <h2>Projets mis en avant</h2>
+        <p class="section-intro">Un aperçu de l’univers Hugz Visuals : textures, lumières dorées et émotions authentiques tournées entre Provence, Côte d’Azur et Pyrénées.</p>
+        <div class="grid-3 grid">
+          <figure class="card fade-in">
+            <img data-src="https://images.unsplash.com/photo-1521310192548-4ac7951413f0?auto=format&fit=crop&w=1200&q=80" alt="Mariage romantique au coucher du soleil" class="lazy" loading="lazy" />
+            <figcaption class="highlight">Mariage doré dans les Alpilles — film intimiste et bande-son originale.</figcaption>
+          </figure>
+          <figure class="card fade-in">
+            <img data-src="https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=1200&q=80" alt="Portrait lifestyle d’une entrepreneure" class="lazy" loading="lazy" />
+            <figcaption class="highlight">Portraits lifestyle pour une créatrice de bijoux artisanaux.</figcaption>
+          </figure>
+          <figure class="card fade-in">
+            <img data-src="https://images.unsplash.com/photo-1469474968028-56623f02e42e?auto=format&fit=crop&w=1200&q=80" alt="Clip vidéo pour un artiste" class="lazy" loading="lazy" />
+            <figcaption class="highlight">Clip musical nocturne pour un artiste émergent marseillais.</figcaption>
+          </figure>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" id="process">
+      <div class="main-wrapper">
+        <h2>Une signature cinématique</h2>
+        <p class="section-intro">Des mouvements lents, des couleurs chaudes, une narration sensible. Chaque projet est pensé comme un court-métrage qui vous ressemble.</p>
+        <div class="process-steps">
+          <div class="process-step fade-in">
+            <span>01</span>
+            <h3>Pré-production intuitive</h3>
+            <p>Échange approfondi, moodboard, repérages, storyboard et préparation logistique pour une captation sereine.</p>
+          </div>
+          <div class="process-step fade-in">
+            <span>02</span>
+            <h3>Captation immersive</h3>
+            <p>Caméras cinéma, drones, lumières naturelles et direction artistique pour sublimer chaque scène.</p>
+          </div>
+          <div class="process-step fade-in">
+            <span>03</span>
+            <h3>Montage émotionnel</h3>
+            <p>Montage rythmé, color grading, sound design et livraison optimisée pour web, réseaux et projection.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section light" id="testimonials">
+      <div class="main-wrapper">
+        <h2>Ils témoignent</h2>
+        <p class="section-intro">Des couples, des marques et des artistes qui ont fait confiance à Hugz Visuals pour raconter leur histoire.</p>
+        <div class="testimonials">
+          <div class="testimonial reveal">
+            <p>« Hugz a transformé notre mariage en une œuvre d’art. Chaque moment est magnifié, chaque émotion ressentie. »</p>
+            <span>Camille & Théo — Mariage</span>
+          </div>
+          <div class="testimonial reveal">
+            <p>« Une approche sensible et professionnelle. Notre campagne a gagné en visibilité grâce à ces images vibrantes. »</p>
+            <span>L’Atelier Céleste — Marque</span>
+          </div>
+          <div class="testimonial reveal">
+            <p>« Son sens du rythme et de la lumière a donné une nouvelle dimension à mon clip. Collaboration fluide et inspirante. »</p>
+            <span>Lazuli — Artiste</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" id="cta">
+      <div class="cta-banner fade-in">
+        <h3>Prêt à donner vie à vos images ?</h3>
+        <p>Parlons de votre projet autour d’un café à Marseille, d’une visio express ou d’un repérage sur site. Je réponds sous 24h.</p>
+        <div class="btn-group">
+          <a href="contact.html" class="btn">Réserver une rencontre</a>
+          <a href="tel:+33600000000" class="btn secondary">Appeler +33 6 00 00 00 00</a>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <div class="inner">
+      <div class="footer-top">
+        <div>
+          <h4>Hugz Visuals</h4>
+          <p>Vidéaste & photographe basé à Marseille. Disponible dans toute la région Sud & au-delà.</p>
+        </div>
+        <div>
+          <h4>Contact</h4>
+          <p><a href="mailto:hello@hugzvisuals.com">hello@hugzvisuals.com</a></p>
+          <p><a href="tel:+33600000000">+33 6 00 00 00 00</a></p>
+        </div>
+        <div>
+          <h4>Suivre</h4>
+          <div class="social-links">
+            <a href="#" aria-label="Instagram">IG</a>
+            <a href="#" aria-label="Vimeo">VI</a>
+            <a href="#" aria-label="YouTube">YT</a>
+          </div>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <span>© <span id="year">2024</span> Hugz Visuals. Tous droits réservés.</span>
+        <a href="mailto:hello@hugzvisuals.com">Parler du prochain projet</a>
+      </div>
+    </div>
+  </footer>
+  <script src="js/main.js" defer></script>
+</body>
+</html>

--- a/js/main.js
+++ b/js/main.js
@@ -1,0 +1,109 @@
+const navToggle = document.querySelector('.mobile-toggle');
+const navLinks = document.querySelector('.nav-links');
+
+if (navToggle && navLinks) {
+  navToggle.addEventListener('click', () => {
+    navLinks.classList.toggle('open');
+    navToggle.setAttribute('aria-expanded', navLinks.classList.contains('open'));
+  });
+
+  navLinks.querySelectorAll('a').forEach((link) => {
+    link.addEventListener('click', () => {
+      if (navLinks.classList.contains('open')) {
+        navLinks.classList.remove('open');
+        navToggle.setAttribute('aria-expanded', 'false');
+      }
+    });
+  });
+}
+
+const observerOptions = {
+  threshold: 0.25,
+};
+
+const fadeElements = document.querySelectorAll('.fade-in, .reveal');
+
+if ('IntersectionObserver' in window) {
+  const observer = new IntersectionObserver((entries, obs) => {
+    entries.forEach((entry) => {
+      if (entry.isIntersecting) {
+        entry.target.classList.add('visible');
+        obs.unobserve(entry.target);
+      }
+    });
+  }, observerOptions);
+
+  fadeElements.forEach((el) => observer.observe(el));
+} else {
+  fadeElements.forEach((el) => el.classList.add('visible'));
+}
+
+const lazyImages = document.querySelectorAll('img[data-src]');
+
+if ('IntersectionObserver' in window) {
+  const lazyObserver = new IntersectionObserver((entries, obs) => {
+    entries.forEach((entry) => {
+      if (entry.isIntersecting) {
+        const img = entry.target;
+        img.src = img.dataset.src;
+        img.addEventListener('load', () => {
+          img.classList.remove('lazy');
+        });
+        obs.unobserve(img);
+      }
+    });
+  }, { rootMargin: '100px 0px', threshold: 0.1 });
+
+  lazyImages.forEach((img) => lazyObserver.observe(img));
+}
+
+const contactForm = document.querySelector('form[data-form="contact"]');
+
+if (contactForm) {
+  contactForm.addEventListener('submit', (event) => {
+    event.preventDefault();
+    const submitBtn = contactForm.querySelector('button[type="submit"]');
+    submitBtn.disabled = true;
+    submitBtn.textContent = 'Envoi en cours...';
+
+    setTimeout(() => {
+      contactForm.reset();
+      submitBtn.disabled = false;
+      submitBtn.textContent = 'Envoyer le message';
+      alert('Merci ! Votre message a été envoyé.');
+    }, 1200);
+  });
+}
+
+const currentPath = window.location.pathname.split('/').pop();
+
+if (navLinks) {
+  navLinks.querySelectorAll('a').forEach((link) => {
+    const href = link.getAttribute('href');
+    if (href === currentPath || (href === 'index.html' && currentPath === '')) {
+      link.classList.add('active');
+    }
+  });
+}
+
+const yearEl = document.getElementById('year');
+if (yearEl) {
+  yearEl.textContent = new Date().getFullYear();
+}
+
+const newsletterForm = document.querySelector('form[data-form="newsletter"]');
+if (newsletterForm) {
+  newsletterForm.addEventListener('submit', (event) => {
+    event.preventDefault();
+    const button = newsletterForm.querySelector('button[type="submit"]');
+    button.disabled = true;
+    button.textContent = 'Inscription en cours...';
+    setTimeout(() => {
+      newsletterForm.reset();
+      button.disabled = false;
+      button.textContent = 'Je m’inscris';
+      alert('Merci ! Vous recevrez bientôt la lettre créative.');
+    }, 1000);
+  });
+}
+

--- a/services.html
+++ b/services.html
@@ -1,0 +1,232 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Services — Hugz Visuals</title>
+  <meta name="description" content="Découvrez les offres photo et vidéo de Hugz Visuals : films de mariage, brand content, clips musicaux, packs sur mesure et prestations corporate." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Montserrat:wght@600;700;800&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="css/style.css" />
+</head>
+<body>
+  <header>
+    <nav class="navbar">
+      <a href="index.html" class="logo">Hugz Visuals</a>
+      <button class="mobile-toggle" aria-label="Ouvrir le menu" aria-expanded="false">
+        <span class="material-symbols-outlined">≡</span>
+      </button>
+      <div class="nav-links">
+        <a href="index.html">Accueil</a>
+        <a href="about.html">À propos</a>
+        <a href="services.html">Services</a>
+        <a href="blog.html">Blog</a>
+        <a href="contact.html" class="btn">Contact</a>
+      </div>
+    </nav>
+  </header>
+  <main>
+    <section class="section">
+      <div class="main-wrapper">
+        <nav aria-label="Fil d’Ariane" class="breadcrumbs">
+          <a href="index.html">Accueil</a>
+          <span>/</span>
+          <span>Services</span>
+        </nav>
+        <div class="split-section large-gap">
+          <div class="fade-in">
+            <span class="badge">Offres & packs</span>
+            <h2>Des services pensés pour vos émotions et vos ambitions</h2>
+            <p>Du storytelling amoureux à la campagne de marque, chaque prestation Hugz Visuals est conçue pour révéler votre identité. Toutes les offres incluent un accompagnement personnalisé, une direction artistique complète et une livraison optimisée pour vos canaux.</p>
+            <div class="btn-group">
+              <a href="contact.html" class="btn">Demander un devis</a>
+              <a href="tel:+33600000000" class="btn secondary">Parler au +33 6 00 00 00 00</a>
+            </div>
+          </div>
+          <div class="card reveal">
+            <h3>Options sur mesure</h3>
+            <ul>
+              <li>Captation drone 4K</li>
+              <li>Montage vertical pour réseaux sociaux</li>
+              <li>Sound design et musique originale</li>
+              <li>Livraison express sous 5 jours ouvrés</li>
+            </ul>
+            <div class="cta-wrap">
+              <a href="mailto:hello@hugzvisuals.com" class="btn secondary">Parlons de vos besoins</a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section alt">
+      <div class="main-wrapper">
+        <h2>Services vidéo</h2>
+        <div class="services-grid">
+          <article class="service-card fade-in">
+            <img src="https://images.unsplash.com/photo-1518895949257-7621c3c786d4?auto=format&fit=crop&w=1200&q=70" alt="Film de mariage cinématique" loading="lazy" />
+            <div class="overlay"></div>
+            <div class="content">
+              <h3>Film de mariage cinématique</h3>
+              <p>Préparation, reportage complet, prises de vues aériennes, montage émotionnel (6 à 10 minutes), teaser 60 secondes.</p>
+              <span class="price">Pack Essentiel — 1800€</span>
+              <ul>
+                <li>Repérage et briefing créatif</li>
+                <li>Captation du matin jusqu’à la soirée</li>
+                <li>Montage colorimétrie cinéma</li>
+                <li>Livraison via galerie privée</li>
+              </ul>
+              <div class="cta-wrap">
+                <a href="contact.html" class="btn">Réserver la date</a>
+              </div>
+            </div>
+          </article>
+
+          <article class="service-card fade-in">
+            <img src="https://images.unsplash.com/photo-1517248135467-4c7edcad34c4?auto=format&fit=crop&w=1200&q=70" alt="Campagne de marque" loading="lazy" />
+            <div class="overlay"></div>
+            <div class="content">
+              <h3>Brand content premium</h3>
+              <p>Conception, tournage et montage de capsules vidéo et photos pour vos campagnes digitales et publicités.</p>
+              <span class="price">Pack Studio — 2400€</span>
+              <ul>
+                <li>Atelier stratégie & moodboard</li>
+                <li>Journée de tournage + photos</li>
+                <li>Montage 3 capsules 30-60 sec</li>
+                <li>Optimisations réseaux sociaux</li>
+              </ul>
+              <div class="cta-wrap">
+                <a href="contact.html" class="btn">Construire la campagne</a>
+              </div>
+            </div>
+          </article>
+
+          <article class="service-card fade-in">
+            <img src="https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=1200&q=70" alt="Clip musical" loading="lazy" />
+            <div class="overlay"></div>
+            <div class="content">
+              <h3>Clip musical narratif</h3>
+              <p>Scénario, direction artistique, tournage multi-caméra, montage rythmé et étalonnage pour artistes indépendants.</p>
+              <span class="price">Pack Vibes — 1600€</span>
+              <ul>
+                <li>Pré-production collaborative</li>
+                <li>1 à 2 jours de tournage</li>
+                <li>Étalonnage style film</li>
+                <li>Version verticale bonus</li>
+              </ul>
+              <div class="cta-wrap">
+                <a href="contact.html" class="btn">Lancer la production</a>
+              </div>
+            </div>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="section light">
+      <div class="main-wrapper">
+        <h2>Photographie</h2>
+        <div class="services-grid">
+          <article class="service-card fade-in">
+            <img src="https://images.unsplash.com/photo-1487412720507-e7ab37603c6f?auto=format&fit=crop&w=1200&q=70" alt="Portrait lifestyle" loading="lazy" />
+            <div class="overlay"></div>
+            <div class="content">
+              <h3>Portraits lifestyle</h3>
+              <p>Séances photo naturelles et direction artistique complète pour entrepreneurs et artistes.</p>
+              <span class="price">Pack Lumière — 420€</span>
+              <ul>
+                <li>Coaching poses & moodboard</li>
+                <li>1h30 de shooting sur site</li>
+                <li>Retouche fine 25 photos</li>
+                <li>Livraison galerie HD</li>
+              </ul>
+              <div class="cta-wrap">
+                <a href="contact.html" class="btn">Réserver un shooting</a>
+              </div>
+            </div>
+          </article>
+
+          <article class="service-card fade-in">
+            <img src="https://images.unsplash.com/photo-1466978913421-dad2ebd01d17?auto=format&fit=crop&w=1200&q=70" alt="Reportage événementiel" loading="lazy" />
+            <div class="overlay"></div>
+            <div class="content">
+              <h3>Reportage événementiel</h3>
+              <p>Couverture photo complète de vos événements corporate, culturels ou privés.</p>
+              <span class="price">Pack Impact — 690€</span>
+              <ul>
+                <li>Brief stratégique</li>
+                <li>Couverture 4 heures</li>
+                <li>Retouche & optimisation web</li>
+                <li>Livraison sous 72h</li>
+              </ul>
+              <div class="cta-wrap">
+                <a href="contact.html" class="btn">Obtenir un devis</a>
+              </div>
+            </div>
+          </article>
+
+          <article class="service-card fade-in">
+            <img src="https://images.unsplash.com/photo-1520854221050-0f4caff449fb?auto=format&fit=crop&w=1200&q=70" alt="Editorial pour marque" loading="lazy" />
+            <div class="overlay"></div>
+            <div class="content">
+              <h3>Editorial de marque</h3>
+              <p>Productions photo créatives, stylisme, moodboard, retouches et déclinaisons pour vos campagnes.</p>
+              <span class="price">Pack Aura — 980€</span>
+              <ul>
+                <li>Préparation artistique complète</li>
+                <li>Shooting studio ou extérieur</li>
+                <li>Livraison pack médias</li>
+                <li>Possibilité de pack photo + vidéo</li>
+              </ul>
+              <div class="cta-wrap">
+                <a href="contact.html" class="btn">Composer votre pack</a>
+              </div>
+            </div>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="cta-banner fade-in">
+        <h3>Besoin d’un format spécifique ?</h3>
+        <p>Je crée aussi des documentaires courts, des aftermovies, des interviews et des contenus pour réseaux sociaux. Parlons de votre prochaine idée.</p>
+        <div class="btn-group">
+          <a href="contact.html" class="btn">Discuter d’un projet</a>
+          <a href="mailto:hello@hugzvisuals.com" class="btn secondary">hello@hugzvisuals.com</a>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <div class="inner">
+      <div class="footer-top">
+        <div>
+          <h4>Hugz Visuals</h4>
+          <p>Vidéaste & photographe basé à Marseille. Disponible dans toute la région Sud & au-delà.</p>
+        </div>
+        <div>
+          <h4>Contact</h4>
+          <p><a href="mailto:hello@hugzvisuals.com">hello@hugzvisuals.com</a></p>
+          <p><a href="tel:+33600000000">+33 6 00 00 00 00</a></p>
+        </div>
+        <div>
+          <h4>Suivre</h4>
+          <div class="social-links">
+            <a href="#" aria-label="Instagram">IG</a>
+            <a href="#" aria-label="Vimeo">VI</a>
+            <a href="#" aria-label="YouTube">YT</a>
+          </div>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <span>© <span id="year">2024</span> Hugz Visuals. Tous droits réservés.</span>
+        <a href="mailto:hello@hugzvisuals.com">Parler du prochain projet</a>
+      </div>
+    </div>
+  </footer>
+  <script src="js/main.js" defer></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- build a responsive multi-page marketing site for Hugz Visuals with reusable navigation, hero, and CTA sections
- implement dedicated About, Services, Blog, Blog Post, and Contact templates with storytelling content and actionable CTAs
- add shared styling and interactions including lazy-loaded media, animations, and mobile navigation handling

## Testing
- no automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d9269222e883329bfde02563b31766